### PR TITLE
타이머 개선(natakgun)

### DIFF
--- a/src/components/gamebox.rs
+++ b/src/components/gamebox.rs
@@ -147,6 +147,10 @@ pub fn game_box() -> Html {
 
                 <div class="flex flex-col justify-between mb-[30px]">
                     <dl class="flex flex-row justify-between">
+                        <dt class="font-mono text-base	">{"Time"}</dt>
+                        <dd id="time" class="font-mono text-base">{"0.00"}</dd>
+                    </dl>
+                    <dl class="flex flex-row justify-between">
                         <dt class="font-mono text-base	">{"Score"}</dt>
                         <dd id="score">{"0"}</dd>
                     </dl>

--- a/src/constants/time.rs
+++ b/src/constants/time.rs
@@ -1,2 +1,2 @@
 // 틱 타임체크용 기준 반복시간 (밀리초)
-pub const TICK_LOOP_INTERVAL: u32 = 100;
+pub const TICK_LOOP_INTERVAL: u32 = 30;

--- a/src/game/board/cell.rs
+++ b/src/game/board/cell.rs
@@ -5,6 +5,7 @@ use wasm_bindgen::prelude::*;
 pub enum Cell {
     Empty = "white",
     Ghost = "#d3d3d3",
+    Garbage = "#424242",
     Red = "red",
     Green = "green",
     Blue = "blue",
@@ -36,6 +37,7 @@ impl std::convert::TryFrom<i32> for Cell {
             6 => Ok(Cell::Orange),
             7 => Ok(Cell::Yellow),
             8 => Ok(Cell::Ghost),
+            9 => Ok(Cell::Garbage),
             _ => Err(()),
         }
     }
@@ -57,6 +59,7 @@ impl Cell {
             Self::Orange => 6,
             Self::Yellow => 7,
             Self::Ghost => 8,
+            Self::Garbage => 9,
             _ => 0,
         }
     }
@@ -72,6 +75,7 @@ impl Cell {
             Self::Orange =>  "#e35c33",
             Self::Yellow =>  "#dc9f09",
             Self::Ghost => "#6d6d6d",
+            Self::Garbage => "#424242",
             _ => "white",
         }
     }

--- a/src/game/game_info.rs
+++ b/src/game/game_info.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 
 use instant::Instant;
 use js_sys::Date;
+use js_sys::Math::{random, floor};
 
 use crate::game::{
     valid_block, valid_tspin, BagType, BlockShape, Board, Cell, ClearInfo, GameRecord, Point,
@@ -353,6 +354,11 @@ impl GameInfo {
                 }
             }
             None => {
+                /* NOTE: fill dummies for testing */
+                let hole_loc = floor(random() * self.board.column_count as f64) as usize;
+                let height = floor(random() * 3 as f64) as usize;
+
+                self.add_garbage_line(hole_loc, height);
                 let block = self.get_block();
                 self.current_block = Some(block);
 

--- a/src/game/game_info.rs
+++ b/src/game/game_info.rs
@@ -168,6 +168,24 @@ impl GameInfo {
         Some(())
     }
 
+    pub fn add_garbage_line(&mut self, hole_loc: usize, height: usize) {
+        let board_height = self.board.cells.len();
+
+        for row in 0..(board_height - height) {
+            self.board.cells[row] = self.board.cells[row + height].clone();
+        }
+
+        for row in 0..height {
+            for (i, cell) in self.board.cells[board_height - 1 - row].iter_mut().enumerate() {
+                *cell = if i == hole_loc {
+                    Cell::Empty
+                } else {
+                    Cell::Garbage
+                };
+            }
+        }
+    }
+
     // 지울 줄이 있을 경우 줄을 지움
     fn clear_line(&mut self) -> ClearInfo {
         let mut line = 0;

--- a/src/game/game_info.rs
+++ b/src/game/game_info.rs
@@ -643,7 +643,6 @@ impl GameInfo {
         self.lose = true;
         self.current_block = None;
         write_text("message", "Game Over".into());
-        self.init_board();
     }
 
     // 보드 초기화

--- a/src/game/game_info.rs
+++ b/src/game/game_info.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 use instant::Instant;
+use js_sys::Date;
 
 use crate::game::{
     valid_block, valid_tspin, BagType, BlockShape, Board, Cell, ClearInfo, GameRecord, Point,
@@ -24,6 +25,7 @@ pub enum GameState {
 pub struct GameInfo {
     pub record: GameRecord,
 
+    pub start_time: Date,
     pub running_time: u128, // 실행시간 (밀리초)
 
     pub game_state: GameState,                     //게임 진행중 여부
@@ -120,6 +122,7 @@ impl GameInfo {
             das: 300,
             sdf: 0, //미사용
             arr: 0, //미사용
+            start_time: Date::new_0(),
             running_time: 0,
             lock_delay_count: 0,
             on_left_move: None,

--- a/src/game/manager.rs
+++ b/src/game/manager.rs
@@ -1,5 +1,6 @@
 use futures_util::stream::StreamExt;
 use gloo_timers::future::IntervalStream;
+use js_sys::Date;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -64,6 +65,7 @@ impl GameManager {
         }
 
         self.game_info.borrow_mut().game_state = GameState::PLAYING;
+        self.game_info.borrow_mut().start_time.set_time(Date::now());
         self.game_info.borrow_mut().lose = false;
 
         log::info!("GAME START");
@@ -87,7 +89,11 @@ impl GameManager {
                     }
                     former_lock_delay_count = game_info.lock_delay_count;
                 }
-                game_info.running_time += TICK_LOOP_INTERVAL as u128;
+
+                game_info.running_time = {
+                    let elapsed_time = Date::now() - game_info.start_time.get_time();
+                    elapsed_time as u128
+                };
 
                 let duration = start_point.elapsed();
 

--- a/src/game/manager.rs
+++ b/src/game/manager.rs
@@ -167,6 +167,7 @@ impl GameManager {
 
                 wasm_bind::render_hold(game_info.hold.map(|e| e.block.into()), 120, 120, 6, 6);
 
+                write_text("time", format!("{:.2}", game_info.running_time as f64 / 1000.0f64));
                 write_text("score", game_info.record.score.to_string());
                 write_text("pc", game_info.record.perfect_clear.to_string());
                 write_text("quad", game_info.record.quad.to_string());

--- a/src/game/manager.rs
+++ b/src/game/manager.rs
@@ -64,6 +64,9 @@ impl GameManager {
             return None
         }
 
+        /* FIXME? */
+        self.game_info.borrow_mut().init_board()?;
+
         self.game_info.borrow_mut().game_state = GameState::PLAYING;
         self.game_info.borrow_mut().start_time.set_time(Date::now());
         self.game_info.borrow_mut().lose = false;


### PR DESCRIPTION
1. 게임상태를 기존 게임중/멈춤 에서 대기/게임중/게임오버로 분할, 게임오버 시 재시작 가능하도록 수정
2. 경과시간 기록을 Tick 사이클 기반이 아닌 시스템상 현재 - 기록된 시작시간 기준으로 수정
3. Tick 체크 사이클을 100ms에서 30ms로 단축